### PR TITLE
Updates for compatibility with webtrees 2.2 API

### DIFF
--- a/module.php
+++ b/module.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Squatteur\Webtrees;
 
 use Composer\Autoload\ClassLoader;
+use Fisharebest\Webtrees\Services\ChartService;
 use Squatteur\Webtrees\BranchStatistics\Module;
 
 // Register our namespace
@@ -20,4 +21,4 @@ $loader->addPsr4(
 $loader->register();
 
 // Create and return instance of the module
-return app(Module::class);
+return new Module(new ChartService());

--- a/src/Module.php
+++ b/src/Module.php
@@ -19,20 +19,20 @@ use Fisharebest\Webtrees\Module\ModuleChartInterface;
 use Fisharebest\Webtrees\Module\ModuleCustomInterface;
 use Fisharebest\Webtrees\Registry;
 use Fisharebest\Webtrees\View;
+use Fisharebest\Webtrees\Webtrees;
 use Squatteur\Webtrees\BranchStatistics\Traits\ModuleChartTrait;
 use Squatteur\Webtrees\BranchStatistics\Traits\ModuleCustomTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-use function app;
 use function is_string;
 use function max;
 use function min;
 use function route;
 
 /**
- * Fan chart module class.
+ * Branch statistics module class.
  *
  * @author  Bestel Squatteur <bestel@squatteur.net>
  * @license https://opensource.org/licenses/GPL-3.0 GNU General Public License v3.0
@@ -82,7 +82,7 @@ class Module extends AbstractModule implements ModuleCustomInterface, ModuleChar
 
     public function boot(): void
     {
-        $router_container = app(RouterContainer::class);
+        $router_container = self::getFromContainer(RouterContainer::class);
 
         $router_container->getMap()
             ->get(static::class, static::ROUTE_URL, $this)
@@ -217,4 +217,20 @@ class Module extends AbstractModule implements ModuleCustomInterface, ModuleChar
         return $title;
     }
 
+    /**
+     * Get from container
+     *
+     * @param string $id
+     * 
+     * @return mixed
+     */
+    public static function getFromContainer(string $id) {
+
+        if (version_compare(Webtrees::VERSION, '2.2.0', '>=')) {
+            return Registry::container()->get($id);
+        }
+        else {
+            return app($id);
+        }    
+    }       
 }


### PR DESCRIPTION
The pull request contains some changes in the custom module API, which are necessary to use the module in webtrees 2.2. With the proposed changes, the module can be used in both, 2.1 and in 2.2

I sucessfully tested the custom module with the changed code in webtrees 2.1 and 2.2