### PR TITLE
Fix issue-16 : value for complete individuals in statics chart

### DIFF
--- a/resources/views/chart.phtml
+++ b/resources/views/chart.phtml
@@ -335,7 +335,7 @@ if ($individual->canShowName()) {
     </thead>
     <tbody>
 		<tr>
-		<td class="facts_value"><meter min="0" low="<?php echo $total/4;?>" high="<?php echo $total/2;?>" optimum="<?php echo $total;?>" max="<?php echo $total;?>" value="<?php echo $sum[$generation_val];?>"></meter><?php echo " ".$complet."/". $total.""; ?></td>
+		<td class="facts_value"><meter min="0" low="<?php echo $total/4;?>" high="<?php echo $total/2;?>" optimum="<?php echo $total;?>" max="<?php echo $total;?>" value="<?php echo $complet; ?>"></meter><?php echo " ".$complet."/". $total.""; ?></td>
 		<td class="facts_value"><?php echo $totalmale;?></td>
 		<td class="facts_value"><?php echo $totalfemale;?></td>
 		<td class="facts_value"><?php echo $totalalive;?></td>


### PR DESCRIPTION
This PR fixes an issue in chart.phtml where the completion meter (count of “complete” individuals vs total individuals processed) incorrectly displayed 0 / X instead of the expected value